### PR TITLE
Change constructor to allow passing of range and bandwidth.

### DIFF
--- a/Arduino/Arduino.ino
+++ b/Arduino/Arduino.ino
@@ -1,39 +1,31 @@
-/*
- * Alex Lima (alexheitorlima@gmail.com)
- * Example using BMA250 class with TinyDuino.
-**/
-
 #include <Wire.h>
 #include "BoschBMA250.h"
 #include <String.h>
 
-// Create BMA250 object.
 BoschBMA250 BMA250;
 
-void setup() 
+void setup()
 {
-    // Initialize communications
-    Serial.begin(115200);
-    BMA250.begin();
+  Serial.begin(9600);
+  BMA250.begin();
 }
 
-// Main application loop
-void loop() 
+void loop()
 {
-  // Read data from accelerometer
   BMA250.read();
-  String message = "X: " + toString(BMA250.getAccelerationX(), 1) + ", " + 
+  String message = "Time: " + toString(millis(),1) + ", " +
+                   "X: " + toString(BMA250.getAccelerationX(), 1) + ", " +
                    "Y: " + toString(BMA250.getAccelerationY(), 1) + ", " +
-                   "Z: " + toString(BMA250.getAccelerationZ(), 1) + ", " + 
-                   "Magnitude: " + toString(BMA250.getVectorMagnitude(), 1) + "\n";
-   Serial.println(message);  
-   delay(100);
-} 
+                   "Z: " + toString(BMA250.getAccelerationZ(), 1);
+                   // "Magnitude: " + toString(BMA250.getVectorMagnitude(), 1) + "\n";
+  Serial.println(message);
+  delay(100);
+}
 
 String toString(double value, int precision)
 {
-    char temp[10];
-    dtostrf(value, 1, precision, temp);
-    String string = String(temp); 
-    return string;
+  char temp[50];
+  dtostrf(value, 1, precision, temp);
+  String string = String(temp);
+  return string;
 }

--- a/Arduino/BoschBMA250.cpp
+++ b/Arduino/BoschBMA250.cpp
@@ -1,74 +1,60 @@
-/*
- * Alex Lima (alexheitorlima@gmail.com), 2014.
- * BoschBMA250 - Library for retrieving data via I2C from the Bosh BMA250 Accelerometer. 
- * [1] Datasheet: http://ae-bst.resource.bosch.com/media/products/dokumente/bma250/bst-bma250-ds002-05.pdf
-**/
-
 #include <Wire.h>
 #include "BoschBMA250.h"
 #include <Arduino.h>
-#include <WProgram.h>
-
-// I2C Address
-#define BMA250_I2CADDR 0x18   
-
-// From "Table 8: Bandwidth Configuration" [1]
-#define BMA250_UPDATE_TIME 0x08
-
-// From "Table 9: Range Selection" [1]
-#define BMA250_RANGE	 0x0A   
 
 BoschBMA250::BoschBMA250(){}
 
-void BoschBMA250::begin()
+void BoschBMA250::begin(int _i2c_address, int update_time, int _range)
 {
-    Wire.begin();			  // Init I2C Transmission
-    setupBandwidth(BMA250_UPDATE_TIME);   // Setup the bandwidth
-    setupRange(BMA250_RANGE);		  // Setup the range measurement
+  i2c_address = _i2c_address;
+  range = _range;
+  Wire.begin();			  // Init I2C Transmission
+  setupBandwidth(update_time);   // Setup the bandwidth
+  setupRange(range);     // Setup the range measurement
 }
 
 void BoschBMA250::setupRange(int range)
 {
-    Wire.beginTransmission(BMA250_I2CADDR);
-    Wire.write(0x0F); 
-    Wire.write(range);
-    Wire.endTransmission();
+  Wire.beginTransmission(i2c_address);
+  Wire.write(BMA250_RANGE_BIT);
+  Wire.write(range);
+  Wire.endTransmission();
 }
 
 void BoschBMA250::setupBandwidth(int bandwidth)
 {
-    Wire.beginTransmission(BMA250_I2CADDR);
-    Wire.write(0x10);
-    Wire.write(bandwidth);
-    Wire.endTransmission();
+  Wire.beginTransmission(i2c_address);
+  Wire.write(BMA250_BANDWIDTH_BIT);
+  Wire.write(bandwidth);
+  Wire.endTransmission();
 }
 
 // Read Data Buffer
 void BoschBMA250::read()
 {
   uint8_t ReadBuff[8];
-  
+
   // Read the 7 data bytes from the BMA250
-  Wire.beginTransmission(BMA250_I2CADDR);
+  Wire.beginTransmission(i2c_address);
   Wire.write(0x02);
   Wire.endTransmission();
-  Wire.requestFrom(BMA250_I2CADDR, 7);
-  
+  Wire.requestFrom(i2c_address, 7);
+
   for(int i = 0; i < 7;i++){
     ReadBuff[i] = Wire.read();
   }
-  
+
   rawX = ReadBuff[1] << 8;
   rawX = rawX | ReadBuff[0];
   rawX = rawX >> 6;
-  
+
   rawY = ReadBuff[3] << 8;
   rawY = rawY | ReadBuff[2];
   rawY = rawY >> 6;
-  
+
   rawZ = ReadBuff[5] << 8;
   rawZ = rawZ | ReadBuff[4];
-  rawZ = rawZ >> 6;  
+  rawZ = rawZ >> 6;
 
   temperature = (ReadBuff[6] * 0.5) + 24.0;
 }
@@ -76,58 +62,59 @@ void BoschBMA250::read()
 // Raw Data
 int BoschBMA250::getRawAccelerationX()
 {
-    return rawX;
+  return rawX;
 }
 
 int BoschBMA250::getRawAccelerationY()
 {
-    return rawY;
+  return rawY;
 }
 
 int BoschBMA250::getRawAccelerationZ()
 {
-    return rawZ;
+  return rawZ;
 }
 
 // A/D Normalization
 double BoschBMA250::normalize(int value)
 {
-    double unit = 4.0 / 1023; // -4/+4G / 1023 (Range); 
-    double normalized = unit * value;
-    return normalized;
+  // Not sure where this magic formula comes from . . .
+  double unit = 4.0 / 1023; // -4/+4G / 1023 (Range);
+  double normalized = unit * value;
+  return normalized;
 }
 
 double BoschBMA250::getAccelerationX()
 {
-    return normalize(rawX);
+  return normalize(rawX);
 }
 
 double BoschBMA250::getAccelerationY()
 {
-    return normalize(rawY);
+  return normalize(rawY);
 }
 
 double BoschBMA250::getAccelerationZ()
 {
-    return normalize(rawZ);
+  return normalize(rawZ);
 }
 
 double BoschBMA250::getVectorMagnitude()
 {
-    double magnitude = sqrt(square(getAccelerationX()) + square(getAccelerationY()) + square(getAccelerationZ()));
-    return magnitude;
+  double magnitude = sqrt(square(getAccelerationX()) + square(getAccelerationY()) + square(getAccelerationZ()));
+  return magnitude;
 }
 
 // Digital Implementation of High Pass Filter (HPF)
 float performHPF(float lastFilteredSample, float sample, float lastSample)
 {
-    float filteredSample = 0.996 * (lastFilteredSample + sample - lastSample);
-    return filteredSample;
+  float filteredSample = 0.996 * (lastFilteredSample + sample - lastSample);
+  return filteredSample;
 }
 
 // Digital Implementation of Low Pass Filter (LPF)
 float performLPF(float alpha, float lastFilteredSample, float sample)
 {
-    float filteredSample = sample * alpha + (lastFilteredSample * (1.0 - alpha));
-    return filteredSample;
+  float filteredSample = sample * alpha + (lastFilteredSample * (1.0 - alpha));
+  return filteredSample;
 }

--- a/Arduino/BoschBMA250.h
+++ b/Arduino/BoschBMA250.h
@@ -1,34 +1,61 @@
 /*
  * Alex Lima (alexheitorlima@gmail.com), 2014.
- * BoschBMA250 - Library for retrieving data via I2C from the Bosh BMA250 Accelerometer. 
+ * BoschBMA250 - Library for retrieving data via I2C from the Bosh BMA250 Accelerometer.
  * [1] Datasheet: http://ae-bst.resource.bosch.com/media/products/dokumente/bma250/bst-bma250-ds002-05.pdf
 **/
 
 #ifndef BoschBMA250_h
 #define BoschBMA250_h
 
+// I2C Address
+#define BMA250_I2CADDR 0x18
+
+// From "Table 8: Bandwidth Configuration" [1]
+// #define BMA250_UPDATE_TIME 0x08
+#define BMA250_BANDWIDTH_BIT       0x10
+#define BMA250_UPDATE_TIME_64ms    0x08
+#define BMA250_UPDATE_TIME_32ms    0x09
+#define BMA250_UPDATE_TIME_16ms    0x0A
+#define BMA250_UPDATE_TIME_8ms     0x0B
+#define BMA250_UPDATE_TIME_4ms     0x0C
+#define BMA250_UPDATE_TIME_2ms     0x0D
+#define BMA250_UPDATE_TIME_1ms     0x0E
+#define BMA250_UPDATE_TIME_.5ms    0x0F
+
+// From "Table 9: Range Selection" [1]
+#define BMA250_RANGE_BIT   0x0F
+#define BMA250_RANGE_2G    0x03
+#define BMA250_RANGE_4G    0x05
+#define BMA250_RANGE_8G    0x08
+#define BMA250_RANGE_16G   0x0C
+// #define BMA250_RANGE   0x0A // What is this magic number?
+
 class BoschBMA250
 {
-	public:
-		BoschBMA250();
-		void begin();
-		void read();
-		int getRawAccelerationX();
-		int getRawAccelerationY();
-		int getRawAccelerationZ();
-                double getAccelerationX();
-                double getAccelerationY();
-                double getAccelerationZ();
-                double getVectorMagnitude();
-         private:
-                double normalize(int value);
-		void init();
-		void setupBandwidth(int bandwidth);
-                void setupRange(int range);
-                int rawX;
-		int rawY;
-		int rawZ;
-		float temperature;
+public:
+  BoschBMA250();
+  void begin(int _i2c_address = BMA250_I2CADDR,
+             int update_time = BMA250_UPDATE_TIME_64ms,
+             int _range = BMA250_RANGE_2G);
+  void read();
+  int getRawAccelerationX();
+  int getRawAccelerationY();
+  int getRawAccelerationZ();
+  double getAccelerationX();
+  double getAccelerationY();
+  double getAccelerationZ();
+  double getVectorMagnitude();
+private:
+  double normalize(int value);
+  void init();
+  void setupBandwidth(int bandwidth);
+  void setupRange(int range);
+  int i2c_address;
+  int range;
+  int rawX;
+  int rawY;
+  int rawZ;
+  float temperature;
 };
 
 #endif


### PR DESCRIPTION
Alex, I changed the constructor to allow for passing of range and bandwidth specifications, while maintaining the original default values.  However, I don't understand a couple of things:

1) Where did the #define BMA250_RANGE	 0x0A   come from?  I don't see in the datasheet where that value is supported.

2) What did the formula double unit = 4.0 / 1023; // -4/+4G / 1023 (Range); come from?  I'm not sure I understand where this normalization formula comes from, and I'm pretty sure that it's not correct for abstract ranges.

I also just noticed that I have some of my own code in the Arduino.ino file, namely adding a timestamp and taking out the magnitude vector.  Please feel free to ignore those changes.

Thanks!

